### PR TITLE
Fixed TCP socket issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ git clone https://github.com/180D-FW-2021/Team3.git
 
 
 # Setup
-## Unity
+## Unity (Game Development Environment)
 
 1. Download and Installl Unity Hub, get the [student version]((https://unity.com/products/unity-student)) if possible
 2. Inside Unity Hub -> Install Unity 2019.4.32f1 (LTS)
 3. In the Projects Tab -> Add -> Team3/Unity Directory
 In Unity -> 
-4. Drag the `Main Scene` under the Assets/Scenes folder in the Project tab into the Hierarchy
+4. Drag the `Menu Scene` under the Assets/Scenes folder in the Project tab into the Hierarchy
 
 ## IMU Plane Control
 1. Go to the Controls Directory
@@ -105,7 +105,7 @@ Keyboard Commands
 - Q: Throttle Decrease
 
 ## Contributors
-- [Leeksun Cho]()
+- [Leeksun Cho](https://github.com/lcho0320)
 - [Moaddat Naqvi](https://github.com/mznaqvi)
 - [Kevin Wiranata](https://github.com/kevinwiranata)
 - [Eric Zhang](https://github.com/Ericzklm)

--- a/Unity/Assets/Airplane/PlaneControl.cs
+++ b/Unity/Assets/Airplane/PlaneControl.cs
@@ -24,6 +24,8 @@ public class PlaneControl : MonoBehaviour
 	public GameObject TimerObject;
 	public CountdownTimer TimerInstance;
 
+	public IMUReader IMUReaderInstance;
+
 	//The game object's Transform  
 	private Transform goTransform;
 
@@ -54,13 +56,19 @@ public class PlaneControl : MonoBehaviour
 		//get this game object's Transform  
 		goTransform = this.GetComponent<Transform>();
 		TimerInstance = TimerObject.GetComponent<CountdownTimer>();
-		await Task.Run(() => ReadIMU());
+		IMUReaderInstance = this.GetComponent<IMUReader>();
+		//await Task.Run(() => ReadIMU());
 	}
 
 
 	// Update is called once per frame
 	void Update()
 	{
+		roll = IMUReaderInstance.roll;
+		pitch = IMUReaderInstance.pitch;
+		boostCount = IMUReaderInstance.boostCount;
+		imuControl = IMUReaderInstance.imuControl;
+		imuDataReceived = IMUReaderInstance.imuDataReceived;
 		if (Gameplay.isPaused)
 		{
 			return;

--- a/Unity/Assets/Airplane/PlaneControl.cs
+++ b/Unity/Assets/Airplane/PlaneControl.cs
@@ -40,7 +40,8 @@ public class PlaneControl : MonoBehaviour
 
 	//the throttle  
 	public float throttle = 1f;
-	public float boost = 1f;
+	public float boost = 0;
+	public int boostFrames = 0;
 
 	// affected by pitch
 	public float airSpeed = 1f;
@@ -50,7 +51,7 @@ public class PlaneControl : MonoBehaviour
 	public int imuDataReceived = 0;
 
 	// Start is called before the first frame update
-	async void Start()
+	void Start()
 	{
 		gameObject.tag = "Plane";
 		//get this game object's Transform  
@@ -69,10 +70,22 @@ public class PlaneControl : MonoBehaviour
 		boostCount = IMUReaderInstance.boostCount;
 		imuControl = IMUReaderInstance.imuControl;
 		imuDataReceived = IMUReaderInstance.imuDataReceived;
+
+		if (boost != 0) 
+		{
+			boostFrames++;
+		}
+		if (boostFrames > 50)
+		{
+			boostFrames = 0;
+			boost = 0;
+		}
+
 		if (Gameplay.isPaused)
 		{
 			return;
 		}
+
 		// Gesture Controls
 		increment = 0.0f;
 		if (getText() == "thumbs up")
@@ -136,6 +149,10 @@ public class PlaneControl : MonoBehaviour
 		if (imuDataReceived == 1)
 		{
 			goTransform.Translate(airSpeed * Vector3.forward);
+			if (boostFrames > 0)
+			{
+				goTransform.Translate(boost * Vector3.forward);
+			}
 			goTransform.Translate(airSpeed * Vector3.right * pitch / 90);
 			transform.rotation = Quaternion.Euler(-1 * roll, goTransform.eulerAngles.y + pitch / 45, -1 * pitch);
 		}
@@ -191,72 +208,6 @@ public class PlaneControl : MonoBehaviour
 				print(err.ToString());
 			}
 		}
-	}
-
-	public void ReadIMU()
-	{
-		IPHostEntry ipHost = Dns.GetHostEntry(Dns.GetHostName());
-		IPAddress ipAddr = ipHost.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork);
-		IPEndPoint localEndPoint = new IPEndPoint(ipAddr, 8081);
-		//IP = "192.168.1.86";
-		//Debug.Log(ipAddr);
-		Debug.Log("Waiting for a connection... host:" + ipAddr.MapToIPv4().ToString());
-
-
-		//IPEndPoint localEndPoint = new IPEndPoint(IPAddress.Parse(IP), 8081);
-
-		Socket listener = new Socket(ipAddr.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-		String[] IMUData;
-		try
-		{
-			listener.Bind(localEndPoint);
-			listener.Listen(10);
-			while (true)
-			{
-				Debug.Log("Waiting for a connection... host:" + ipAddr.MapToIPv4().ToString());
-				Socket clientSocket = listener.Accept();
-				imuControl = 1;
-
-				byte[] bytes = new Byte[1024];
-				string data = null;
-
-				while (true)
-				{
-					int numByte = clientSocket.Receive(bytes);
-					data = Encoding.ASCII.GetString(bytes, 0, numByte);
-					IMUData = data.Split(';');
-					imuDataReceived = 1;
-					foreach (var Reading in IMUData)
-					{
-						if (!String.IsNullOrEmpty(Reading))
-						{
-							//Debug.Log(Reading);
-							String[] IMUValues = Reading.Split(',');
-							roll = -1 * float.Parse(IMUValues[0]) / 4; //* 60;
-							pitch = -1 * float.Parse(IMUValues[1]) / 4; //* 60;
-							if (IMUValues[2] == "1")
-							{
-								this.boostCount++;
-								this.airSpeed = 2f;
-							}
-						}
-					}
-					//Debug.Log(data);
-				}
-				clientSocket.Shutdown(SocketShutdown.Both);
-				clientSocket.Close();
-			}
-		}
-		catch (Exception e)
-		{
-			Debug.Log(e.ToString());
-		}
-	}
-
-	public void Service(CancellationToken token)
-	{
-
 	}
 
 	void setText(string text)

--- a/Unity/Assets/Scenes/Main Scene.unity
+++ b/Unity/Assets/Scenes/Main Scene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 0.25
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 984039097}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 0.25}
+  m_IndirectSpecularColor: {r: 0.19805709, g: 0.2195459, b: 0.25603554, a: 0.25}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -527,6 +527,7 @@ MonoBehaviour:
   txPort: 8001
   TimerObject: {fileID: 1647500450}
   TimerInstance: {fileID: 0}
+  IMUReaderInstance: {fileID: 0}
   roll: 0
   pitch: 0
   throttle: 1
@@ -566,6 +567,26 @@ MonoBehaviour:
   throttle: {fileID: 2065347045}
   speed: {fileID: 1792598517}
   altitude: {fileID: 2142886894}
+--- !u!114 &116129728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 116129724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa1f0c31d17a11046bd2315756d41fce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  roll: 0
+  pitch: 0
+  boostCount: 0
+  imuControl: 0
+  imuDataReceived: 0
+  boost: 0
+  TimerObject: {fileID: 1647500450}
+  TimerInstance: {fileID: 0}
 --- !u!65 &116129729
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Unity/Assets/Scripts/ButtonHandler.cs
+++ b/Unity/Assets/Scripts/ButtonHandler.cs
@@ -8,7 +8,7 @@ public class ButtonHandler : MonoBehaviour
 	// Start is called before the first frame update
 	public void startGame()
 	{
-		SceneManager.LoadScene("Main Scene");
+		SceneManager.LoadSceneAsync("Main Scene");
 	}
 
 	public void quitGame()

--- a/Unity/Assets/Scripts/IMUReader.cs
+++ b/Unity/Assets/Scripts/IMUReader.cs
@@ -64,7 +64,6 @@ public class IMUReader : MonoBehaviour
                             imuData = serverMessage.Split(';');
                             foreach (var Reading in imuData)
                             {
-                                Debug.Log(Reading);
                                 if (!String.IsNullOrEmpty(Reading))
                                 {
                                     String[] IMUValues = Reading.Split(',');
@@ -72,7 +71,6 @@ public class IMUReader : MonoBehaviour
                                     pitch = -1 * float.Parse(IMUValues[1]) / 4; //* 60;
                                     if (IMUValues[2][0] == '1')
                                     {
-                                        Debug.Log("Here");
                                         this.boostCount++;
                                         PlaneControlInstance.boost = 10f;
                                     }

--- a/Unity/Assets/Scripts/IMUReader.cs
+++ b/Unity/Assets/Scripts/IMUReader.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using UnityEngine;
+
+public class IMUReader : MonoBehaviour
+{
+    public float roll;
+    public float pitch;
+
+    public int boostCount = 0;
+	public int imuControl = 0;
+	public int imuDataReceived = 0;
+    public int boost = 0;
+
+    private TcpListener tcpListener;
+    private TcpClient tcpClient;
+    private Thread IMUThread;
+
+    public GameObject TimerObject;
+	public CountdownTimer TimerInstance;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        //DontDestroyOnLoad(this.gameObject);
+        TimerInstance = TimerObject.GetComponent<CountdownTimer>();
+        IMUThread = new Thread(new ThreadStart(ReadIMU));
+		IMUThread.IsBackground = true;
+		IMUThread.Start();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public void ReadIMU()
+	{
+		IPHostEntry ipHost = Dns.GetHostEntry(Dns.GetHostName());
+		IPAddress ipAddr = ipHost.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork);
+		String[] imuData;
+        try 
+        {
+            tcpListener = new TcpListener(ipAddr, 8081);
+            tcpListener.Start();
+            Debug.Log("Server Listening at " + ipAddr.MapToIPv4().ToString());
+            imuControl = 1;
+            Byte[] bytes = new Byte[1024];
+            while (true) {
+                using (tcpClient = tcpListener.AcceptTcpClient())
+                {
+                    using (NetworkStream stream = tcpClient.GetStream())
+                    {
+                        int length;
+                        while ((length = stream.Read(bytes, 0, bytes.Length)) != 0)
+                        {
+                            var incomingData = new byte[length];
+                            Array.Copy(bytes, 0, incomingData, 0, length);
+                            string serverMessage = Encoding.ASCII.GetString(incomingData);
+                            imuDataReceived = 1;
+                            imuData = serverMessage.Split(';');
+                            foreach (var Reading in imuData)
+                            {
+                                Debug.Log(Reading);
+                                if (!String.IsNullOrEmpty(Reading))
+                                {
+                                    String[] IMUValues = Reading.Split(',');
+                                    roll = -1 * float.Parse(IMUValues[0]) / 4; //* 60;
+                                    //Debug.Log(roll);
+                                    pitch = -1 * float.Parse(IMUValues[1]) / 4; //* 60;
+                                    if (IMUValues[2] == "1")
+                                    {
+                                        this.boostCount++;
+                                        //this.airSpeed = 2f;
+                                    }
+                                }
+                            }
+                            if (TimerInstance.timeLeft <= 0)
+                            {
+                                break;
+                            }
+                        }
+                        if (TimerInstance.timeLeft <= 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        catch (SocketException SocketException)
+        {
+            Debug.Log("Socket Exception: " + SocketException);
+        }
+	}
+}

--- a/Unity/Assets/Scripts/IMUReader.cs
+++ b/Unity/Assets/Scripts/IMUReader.cs
@@ -16,7 +16,6 @@ public class IMUReader : MonoBehaviour
     public int boostCount = 0;
 	public int imuControl = 0;
 	public int imuDataReceived = 0;
-    public int boost = 0;
 
     private TcpListener tcpListener;
     private TcpClient tcpClient;
@@ -25,20 +24,17 @@ public class IMUReader : MonoBehaviour
     public GameObject TimerObject;
 	public CountdownTimer TimerInstance;
 
+    public PlaneControl PlaneControlInstance;
+
     // Start is called before the first frame update
     void Start()
     {
         //DontDestroyOnLoad(this.gameObject);
         TimerInstance = TimerObject.GetComponent<CountdownTimer>();
+        PlaneControlInstance = this.GetComponent<PlaneControl>();
         IMUThread = new Thread(new ThreadStart(ReadIMU));
 		IMUThread.IsBackground = true;
 		IMUThread.Start();
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
     }
 
     public void ReadIMU()
@@ -73,12 +69,12 @@ public class IMUReader : MonoBehaviour
                                 {
                                     String[] IMUValues = Reading.Split(',');
                                     roll = -1 * float.Parse(IMUValues[0]) / 4; //* 60;
-                                    //Debug.Log(roll);
                                     pitch = -1 * float.Parse(IMUValues[1]) / 4; //* 60;
-                                    if (IMUValues[2] == "1")
+                                    if (IMUValues[2][0] == '1')
                                     {
+                                        Debug.Log("Here");
                                         this.boostCount++;
-                                        //this.airSpeed = 2f;
+                                        PlaneControlInstance.boost = 10f;
                                     }
                                 }
                             }

--- a/Unity/Assets/Scripts/IMUReader.cs.meta
+++ b/Unity/Assets/Scripts/IMUReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa1f0c31d17a11046bd2315756d41fce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Scripts/StreamingRecognizer.cs
+++ b/Unity/Assets/Scripts/StreamingRecognizer.cs
@@ -284,10 +284,10 @@ public class StreamingRecognizer : MonoBehaviour
 					Debug.Log(transcript);
 				}
 
-				// if (transcript.ToLower().Contains("start"))
-				// {
-				// 	Gameplay.startGame();
-				// }
+				if (transcript.ToLower().Contains("start"))
+				{
+				 	Gameplay.startGame();
+				}
 				if (transcript.Contains("pause"))
 				{
 					Gameplay.pauseGame();
@@ -300,10 +300,10 @@ public class StreamingRecognizer : MonoBehaviour
 				{
 					Gameplay.enableKeyboard();
 				}
-				// else if (transcript.ToLower().Contains("quit"))
-				// {
-				// 	Gameplay.quitGame();
-				// }
+				else if (transcript.ToLower().Contains("quit"))
+				{
+					Gameplay.quitGame();
+				}
 				// else if (transcript.ToLower().Contains("restart"))
 				// {
 				// 	Gameplay.restartGame();

--- a/Unity/Assets/StreamingAssets/gcp_credentials.json.meta
+++ b/Unity/Assets/StreamingAssets/gcp_credentials.json.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: abab60b6c637243dd9e82ed25d2f0e1b
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Fixed issues between scene loading and TCP thread spawning. In order to avoid issues from here on out, make sure only the menu scene is present in the hierarchy when starting the game. This hotfix includes the modularization of the IMU reader code as well as a threading fix to ensure our worker thread is killed at the end of the game.

Fixes #29 